### PR TITLE
construct PyNode from SExp

### DIFF
--- a/src/py/py_node.rs
+++ b/src/py/py_node.rs
@@ -62,7 +62,12 @@ impl PyNode {
             if let Ok(r) = n {
                 r
             } else {
-                extract_tuple(&allocator, obj)?
+                let n = extract_tuple(&allocator, obj);
+                if let Ok(r) = n {
+                    r
+                } else {
+                    extract_node(&allocator, obj)?
+                }
             }
         };
         Ok(node)


### PR DESCRIPTION
amend PyNode constructor to also allow creating one from another PyNode (e.g. SExp). This fixes the test case in clvm/tests/to_sexp_test.py