### PR TITLE
simplify, factor out and unit test parts of path traversal

### DIFF
--- a/src/reduction.rs
+++ b/src/reduction.rs
@@ -1,7 +1,7 @@
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct EvalErr<T>(pub T, pub String);
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Reduction<T>(pub u32, pub T);
 
 pub type Response<T> = Result<Reduction<T>, EvalErr<T>>;


### PR DESCRIPTION
this patch makes `traverse_path()` take the path index directly, rather than an SExp. It has already been pulled out by the caller, so we might as well pass it in.

It also factors out a small loop into a separate function to allow unit testing of it.

It also adds a unit test for the `traverse_path()` function itself.